### PR TITLE
ENH: Add GitHub contributing instructions, support instructions and templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing
+
+## Getting Started
+
+* Make sure you have a [GitHub account](https://github.com/signup/free)
+* Submit a ticket for your issue, assuming one does not already exist.
+  * Clearly describe the issue including steps to reproduce when it is a bug.
+  * Make sure you fill in the earliest version that you know has the issue.
+* Fork the repository on GitHub
+
+
+## Making Changes
+
+* Create a topic branch from where you want to base your work.
+  * This is usually the master branch.
+  * Only target release branches if you are certain your fix must be on that
+    branch.
+  * To quickly create a topic branch based on master; `git checkout -b
+    fix/master/my_contribution master`. Please avoid working directly on the
+    `master` branch.
+* Make commits of logical units.
+* Check for unnecessary whitespace with `git diff --check` before committing.
+* Make sure your commit messages are in the proper format (see below)
+* Make sure you have added the necessary tests for your changes.
+* Run _all_ the tests to assure nothing else was accidentally broken.
+
+### Writing the commit message
+
+Commit messages should be clear and follow a few basic rules. Example:
+
+```
+ENH: add functionality X to optimizer.<submodule>.
+
+The first line of the commit message starts with a capitalized acronym
+(options listed below) indicating what type of commit this is.  Then a blank
+line, then more text if needed.  Lines shouldn't be longer than 72
+characters.  If the commit is related to a ticket, indicate that with
+"See #3456", "See ticket 3456", "Closes #3456" or similar.
+```
+
+Describing the motivation for a change, the nature of a bug for bug fixes 
+or some details on what an enhancement does are also good to include in a 
+commit message. Messages should be understandable without looking at the code 
+changes. 
+
+Standard acronyms to start the commit message with are:
+
+
+|Code| Description                                        |
+|----|----------------------------------------------------|
+|API | an (incompatible) API change                       |
+|BLD | change related to building                         |
+|BUG | bug fix                                            |
+|DEP | deprecate something, or remove a deprecated object |
+|DEV | development tool or utility                        |
+|DOC | documentation                                      |
+|ENH | enhancement                                        |
+|MNT | maintenance commit (refactoring, typos, etc.)      |
+|REV | revert an earlier commit                           |
+|STY | style fix (whitespace, PEP8)                       |
+|TST | addition or modification of tests                  |
+|REL | related to releasing numpy                         |
+|WIP | Commit that is a work in progress                  |
+
+## The Pull Request
+
+* Now push to your fork
+* Submit a [pull request](https://help.github.com/articles/using-pull-requests) to this branch. This is a start to the conversation.
+
+At this point you're waiting on us. We like to at least comment on pull requests within three business days 
+(and, typically, one business day). We may suggest some changes or improvements or alternatives.
+
+Hints to make the integration of your changes easy (and happen faster):
+- Keep your pull requests small
+- Don't forget your unit tests
+- All algorithms need documentation, don't forget the .rst file
+- Don't take changes requests to change your code personally

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Let us know if something is broken on Ocelot Optimizer.
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description the bug -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen -->
+
+**Steps to Reproduce**
+<!-- Steps to reproduce the bug -->
+
+**Possible Solution**
+<!--
+    Not obligatory, but suggest a fix/reason for the bug, or ideas how to 
+    implement the addition or change.
+--> 
+
+**My Platform**
+<!--
+    Any details about your specific platform:
+    * OS Version
+    * Python Version
+    * Packages Version
+-->
+
+**Additional context**
+<!-- Add any other context, links, etc. about the bug here. -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest a new feature for Ocelot Optimizer 
+
+---
+
+**What's the problem this feature will solve?**
+<!-- A clear and concise description of what the problem is. -->
+
+**Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Additional context**
+<!-- Add any other context, links, etc. about the feature here. -->

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,18 @@
+### Getting Started
+
+### Bug reports & Feature request
+
+If you spot a problem with Ocelot Optimizer, please let us know by following the template in
+here: [Report a bug](https://github.com/ocelot-collab/optimizer/issues/new?template=bug-report.md).
+
+Ideas or suggestions for enhancements are more than welcome. Please use the following
+template in here: [Request feature](https://github.com/ocelot-collab/optimizer/issues/new?template=feature-request.md).
+
+### Contact us
+
+If you have questions of comments in general about Ocelot Optmizer we want to know.
+
+You can choose between the channels open for communication the one that best fit you:
+
+- Chat channel using [Slack](<https://ocelot-project.slack.com/>) (Public)
+- [File a bug](https://github.com/ocelot-collab/optimizer/issues/new?template=bug-report.md) and let us know where our documentation could be improved.


### PR DESCRIPTION
This Pull Request add a couple of useful GitHub machinery.
- Template for Bugs and Requests
- Contributing Instructions
- Support Instructions